### PR TITLE
Add basic rustfmt file

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,4 @@
+max_width = 78
+comemnt_width = 78
+normalize_comments = false
+wrap_comments = true


### PR DESCRIPTION
78-character wrapping, including for comments.

Signed-off-by: Robbie Harwood <rharwood@redhat.com>