### PR TITLE
Use bindgen correctly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,6 @@ matrix:
 before_script:
 - export PATH="$PATH:$HOME/.cargo/bin"
 - rustup component add rustfmt
-- cargo install bindgen
 
 script:
 - cargo build --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,6 @@ libc = "0.2.60"
 [lib]
 crate-type = ["cdylib"]
 name = "cipherpipe"
+
+[build-dependencies]
+bindgen = "0.51"

--- a/build.rs
+++ b/build.rs
@@ -12,18 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+extern crate bindgen;
+
+use std::env;
+use std::path::PathBuf;
+
 fn main() {
-    use std::path::Path;
+    println!("cargo:rerun-if-changed=src/header.h");
 
-    let dir = std::env::var("OUT_DIR").unwrap();
+    let bindings = bindgen::Builder::default()
+        .header("src/header.h")
+        .generate()
+        .expect("Unable to generate bindings");
 
-    let src = Path::new("src").join("header.h");
-    let dst = Path::new(&dir).join("header.rs");
-
-    std::process::Command::new("bindgen")
-        .arg(src)
-        .arg("-o")
-        .arg(dst)
-        .output()
-        .expect("failed to generate bindings from the header");
+    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+    bindings
+        .write_to_file(out_path.join("header.rs"))
+        .expect("Couldn't write bindings!");
 }


### PR DESCRIPTION
This is the recommended method for using bindgen.  Additionally, in this
way we avoid having to explain to users that they need to separately
procure a `bindgen` executable.

Signed-off-by: Robbie Harwood <rharwood@redhat.com>